### PR TITLE
fix: exclude the test file from bundle

### DIFF
--- a/tests/no-side-effects-in-initialization.test.ts
+++ b/tests/no-side-effects-in-initialization.test.ts
@@ -1,10 +1,10 @@
-/* Possible improvements for rollup:
- * * Properly handle valid this values
- * * Deleting an object expression member whose value is a global does not need to be a side-effect
+/** Possible improvements for rollup:
+ * Properly handle valid this values
+ * Deleting an object expression member whose value is a global does not need to be a side-effect
  */
 
 import { describe, it } from "vitest";
-import { noSideEffectsInInitialization as rule } from "./no-side-effects-in-initialization";
+import { noSideEffectsInInitialization as rule } from "../src/rules/no-side-effects-in-initialization";
 import { Linter, RuleTester } from "eslint";
 import { rollup } from "rollup";
 

--- a/tests/no-side-effects-in-initialization.test.ts
+++ b/tests/no-side-effects-in-initialization.test.ts
@@ -1,6 +1,6 @@
-/** Possible improvements for rollup:
- * Properly handle valid this values
- * Deleting an object expression member whose value is a global does not need to be a side-effect
+/*  Possible improvements for rollup:
+ * - Properly handle valid this values
+ * - Deleting an object expression member whose value is a global does not need to be a side-effect
  */
 
 import { describe, it } from "vitest";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
-  }
+  },
+  "include":["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include":["src"]
+  "include": ["src"]
 }


### PR DESCRIPTION
on v1.12.0
![image](https://github.com/lukastaegert/eslint-plugin-tree-shaking/assets/74761884/a4248973-040c-493f-998d-7b2e4dc4b8aa)

on v1.12.1   with .test file
![image](https://github.com/lukastaegert/eslint-plugin-tree-shaking/assets/74761884/f35c2ce7-84bd-4d51-9453-8b4f29365dd7)
